### PR TITLE
Fix history_from_git path bug

### DIFF
--- a/2022/history_from_git.py
+++ b/2022/history_from_git.py
@@ -5,6 +5,7 @@ import gspread
 import subprocess
 import time
 import xmltodict
+import os
 
 sheetkey = "1XUz_SZCHG6DOswnzzHpyI7CkBUMnjq904xX3Zarudxo"
 
@@ -29,9 +30,10 @@ hashes.reverse()
 kk = 1
 for hash in hashes:
     subprocess.run(["git", "checkout", hash])
-    with open("../social.xml") as fin:
+    file_path = os.path.join(os.path.dirname(__file__), "social.xml")
+    with open(file_path, "r", encoding="utf-8") as fin:
         xmlb = fin.read()
-        xml = (bytes(xmlb, encoding='utf8'))
+        xml = bytes(xmlb, encoding="utf8")
 
     data = {}
     main = xmltodict.parse(xml)


### PR DESCRIPTION
## Summary
- fix history_from_git path to `social.xml`
- import `os` to compute script directory

## Testing
- `python -m py_compile 2022/history_from_git.py`
- `python -m py_compile 2022/daily.py`

------
https://chatgpt.com/codex/tasks/task_e_68447bff8508832ba98d34ae467439ba